### PR TITLE
Num cores flexible

### DIFF
--- a/pandas_dedupe/link_dataframes.py
+++ b/pandas_dedupe/link_dataframes.py
@@ -11,7 +11,7 @@ import pandas as pd
 
 
 
-def link_dataframes(dfa, dfb, field_properties, config_name="link_dataframes"):
+def link_dataframes(dfa, dfb, field_properties, config_name="link_dataframes", n_cores=None):
     
     config_name = config_name.replace(" ", "_")
     
@@ -49,7 +49,7 @@ def link_dataframes(dfa, dfb, field_properties, config_name="link_dataframes"):
     if os.path.exists(settings_file):
         print('Reading from', settings_file)
         with open(settings_file, 'rb') as sf :
-            linker = dedupe.StaticRecordLink(sf, num_cores=None)
+            linker = dedupe.StaticRecordLink(sf, num_cores=n_cores)
 
     else:
         # Define the fields the linker will pay attention to
@@ -63,7 +63,7 @@ def link_dataframes(dfa, dfb, field_properties, config_name="link_dataframes"):
               
                 
         # Create a new linker object and pass our data model to it.
-        linker = dedupe.RecordLink(fields, num_cores=None)
+        linker = dedupe.RecordLink(fields, num_cores=n_cores)
         # To train the linker, we feed it a sample of records.
         linker.prepare_training(data_1, data_2, sample_size=15000)
 


### PR DESCRIPTION
Pull request to add the argument `n_cores` to both `dedupe_dataframe` and `link_dataframes`.
With the addition of `n_cores`, the user will be able to specify the number of cores to be used during clustering (default: CPU count).

This pul request will be a fix for the following issues: [#30](https://github.com/Lyonk71/pandas-dedupe/issues/30) and [#29](https://github.com/Lyonk71/pandas-dedupe/issues/29) 