### PR TITLE
Added Explicit Mention Of Regex To Fix Warning Pandas Gives About Changing Default From Regex True To Regex False

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,16 @@
+# Python Interpreter Files
 */__pycache__/*
 .python-version
+
+# Dedupe Data
 *_learned_settings
 *_training.json
+
+# OSX Files
+.DS_Store
+
+# Intellij IDEA Files
+.idea
+
+# Virtual Environment
+venv

--- a/pandas_dedupe/utility_functions.py
+++ b/pandas_dedupe/utility_functions.py
@@ -14,7 +14,7 @@ def clean_punctuation(df):
         df[i] = df[i].astype(str) 
     df = df.applymap(lambda x: x.lower())
     for i in df.columns:
-        df[i] = df[i].str.replace('[^\w\s\.\-\(\)\,\:\/\\\\]','')
+        df[i] = df[i].str.replace('[^\w\s\.\-\(\)\,\:\/\\\\]','', regex=True)
     df = df.applymap(lambda x: trim(x))
     df = df.applymap(lambda x: unidecode(x))
     for i in df.columns:
@@ -56,7 +56,7 @@ def specify_type(df, field_properties):
             df[i[0]] = df[i[0]].apply(lambda x: latlong_datatype(x))
         elif i[1] == 'Price':
             try:
-                df[i[0]] = df[i[0]].str.replace(",","")
+                df[i[0]] = df[i[0]].str.replace(",","", regex=False)
                 df[i[0]] = df[i[0]].replace({None: np.nan})
                 df[i[0]] = df[i[0]].astype(float)
                 df[i[0]] = df[i[0]].replace({np.nan: None})


### PR DESCRIPTION
As Pandas has been phasing out having the replace function default to Regex in favor of having it default to regular matching, Pandas gives a warning when not explicitly specifying whether or not to use Regex.

This PR will remove that warning by explicitly specifying whether or not to use Regex, and will also prevent this module from breaking in the future when the warning is removed and Regex is defaulted to off.